### PR TITLE
[ENHANCEMENT]: Global variable for allowed headers across all routes

### DIFF
--- a/iguide_cors.js
+++ b/iguide_cors.js
@@ -7,7 +7,8 @@ const allowedOrigins = process.env.ALLOWED_DOMAIN_LIST ? JSON.parse(process.env.
 export const jwtCorsOptions = {
     origin: `${process.env.FRONTEND_DOMAIN}`,
     methods: 'GET, POST, PUT, DELETE, OPTIONS',
-    allowedHeaders: 'Origin, X-Requested-With, Content-Type, Accept, Authorization, JWT-API-KEY'
+    allowedHeaders: 'Origin, X-Requested-With, Content-Type, Accept, Authorization, JWT-API-KEY',
+    allowedHeadersWithoutAuth: 'Origin, X-Requested-With, Content-Type, Accept, JWT-API-KEY'
 };
 
 export const jwtCorsMiddleware = (req, res, next) => {

--- a/routes/documentation.js
+++ b/routes/documentation.js
@@ -38,12 +38,12 @@ router.options('/documentation', (req, res) => {
     if (method === 'POST') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'POST');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', method);
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeadersWithoutAuth);
     }
     res.sendStatus(204); // No content
 });
@@ -53,17 +53,17 @@ router.options('/documentation/:id', (req, res) => {
     if (method === 'PUT') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'PUT');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'DELETE') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'DELETE');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     }else {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', method);
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeadersWithoutAuth);
     }
     res.sendStatus(204); // No content
 });

--- a/routes/elements.js
+++ b/routes/elements.js
@@ -433,21 +433,21 @@ router.options('/api/elements/:id', (req, res) => {
     if (method === 'PUT') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'PUT');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'POST') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'POST');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'GET') {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', 'GET');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeadersWithoutAuth);
     }else if (method === 'DELETE') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'DELETE');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     }
     res.sendStatus(204); // No content
@@ -458,21 +458,21 @@ router.options('/api/elements', (req, res) => {
     if (method === 'PUT') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'PUT');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'POST') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'POST');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'GET') {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', 'GET');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeadersWithoutAuth);
     }else if (method === 'DELETE') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'DELETE');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     }
     res.sendStatus(204); // No content

--- a/routes/users.js
+++ b/routes/users.js
@@ -435,12 +435,12 @@ router.options('/api/users/:id', (req, res) => {
     if (method === 'PUT') {
         res.header('Access-Control-Allow-Origin', jwtCORSOptions.origin);
         res.header('Access-Control-Allow-Methods', 'PUT');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeaders);
         res.header('Access-Control-Allow-Credentials', 'true');
     } else if (method === 'GET') {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Methods', 'GET');
-        res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+        res.header('Access-Control-Allow-Headers', jwtCorsOptions.allowedHeadersWithoutAuth);
     }
     res.sendStatus(204); // No content
 });


### PR DESCRIPTION
## Why this change?
This change is brought to standardize the allowed headers for each request across all routes

## Why do we need to standardize the allowed headers values?
- We have recently added a new header `JWT-API-KEY` token which is used to allow frontend development to work on their local machine and point to dev backend without the need to deploy their changes onto their frontend branches.
- In future if we expand to take in more headers for secure authentication or information, current implementation will require to make the change in each file every time.
- This change allows us to make global changes across all routes for any headers change with one addition/deletion in the iguide_cors.js

## What is the change made?
- Created 2 new variables in `jwtCorsOptions` known as `allowedHeaders` and `allowedHeadersWithoutAuth` to support for both type of requests which require `Authorization` and which do not.