### PR TITLE
[HotFix] OERshare

### DIFF
--- a/routes/elements.js
+++ b/routes/elements.js
@@ -720,14 +720,19 @@ router.post('/api/elements',
     try {
         console.log('Registering ' + resource['resource-type'] + 'by ' + user_id);
         // Check if the resource type is "oer" and user have enough permission to add OER
-        if (resource['resource-type'] === 'oer' &&
-	    !(user_role <= utils.Role.UNRESTRICTED_CONTRIBUTOR)) {
+        // HotFix: OERshare
+	    if (resource['resource-type'] === 'oer' &&
+	    !(user_role <= utils.Role.TRUSTED_USER_PLUS)) {
             console.log(user_id, " blocked by role")
             return res.status(403).json({ message: 'Forbidden: You do not have permission to submit OER elements.' });
         }else{
             console.log(user_id, " is allowed to submit oers")
         }
-
+	// HotFix: OERshare
+	if (resource['resource-type'] === 'oer' &&
+	    (user_role == utils.Role.TRUSTED_USER_PLUS)) {
+		resource['tags'].push('OERshare')
+	}
 		/**
 		 * Updated logic building the repo details,
 		 * 	In the request resource['notebook-url']


### PR DESCRIPTION
 - Update permissions to allow OER submissions from TRUSTED_USER_PLUS
 - To keep track of curated vs. non-curated OERs, append 'OERshare' tag to OER submissions from TRUSTED_USER_PLUS